### PR TITLE
chore: add collectives chain spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ All chain specification files can be found at the following base URL:
 
 Available chain specification files:
 
+- [paseo-collectives.raw.json](https://paseo-r2.zondax.ch/chain-specs/paseo-collectives.raw.json)
 - [paseo-asset-hub.json](https://paseo-r2.zondax.ch/chain-specs/paseo-asset-hub.json)
 - [paseo-bridge-hub.raw.json](https://paseo-r2.zondax.ch/chain-specs/paseo-bridge-hub.raw.json)
 - [paseo-coretime.raw.json](https://paseo-r2.zondax.ch/chain-specs/paseo-coretime.raw.json)


### PR DESCRIPTION
Adds a link to the collectives chain specification file in the README.
This improves discoverability of available chain specifications.


<!-- ClickUpRef: 869acj89j -->
:link: [zboto Link](https://app.clickup.com/t/869acj89j)